### PR TITLE
Fix Dir.chdir nested with multiple absolute paths.

### DIFF
--- a/lib/fakefs/file_system.rb
+++ b/lib/fakefs/file_system.rb
@@ -92,9 +92,11 @@ module FakeFS
     def normalize_path(path)
       if Pathname.new(path).absolute?
         File.expand_path(path)
+      elsif dir_levels.empty?
+        File.expand_path(path)
       else
         parts = dir_levels + [path]
-        File.expand_path(File.join(*parts))
+        parts.inject {|base, part| Pathname(base) + part }.expand_path.to_s
       end
     end
 

--- a/test/fakefs_test.rb
+++ b/test/fakefs_test.rb
@@ -1156,6 +1156,19 @@ class FakeFSTest < Test::Unit::TestCase
     assert_equal ['/path/me/foobar'], Dir.glob('/path/me/*').sort
   end
 
+  def test_chdir_should_be_nestable_with_absolute_paths
+    FileUtils.mkdir_p '/path/me'
+    Dir.chdir '/path' do
+      File.open('foo', 'w') { |f| f.write 'foo'}
+      Dir.chdir '/path/me' do
+        File.open('foobar', 'w') { |f| f.write 'foo'}
+      end
+    end
+
+    assert_equal ['/path/foo','/path/me'], Dir.glob('/path/*').sort
+    assert_equal ['/path/me/foobar'], Dir.glob('/path/me/*').sort
+  end
+
   def test_chdir_should_flop_over_and_die_if_the_dir_doesnt_exist
     assert_raise(Errno::ENOENT) do
       Dir.chdir('/nope') do


### PR DESCRIPTION
The previous implementation used `File.join(*paths)`, which blindly concatenates path components and should not be used for path resolution.  As a result, the following has unexpected behavior:

``` ruby
# EXPECTED
#
#   Dir.pwd => "/path/to/here"
#   FakeFS::FileSystem.normalize_path('.') => "/path/to/here"
#
# ACTUAL
#
#   Dir.pwd => ""
#   FakeFS::FileSystem.normalize_path('.') => "/path/to/here/path/to/here"
#
FileUtils.mkdir_p('/path/to/here')
Dir.chdir('/path/to/here') do
  Dir.chdir('/path/to/here') do
    puts "Dir.pwd => #{Dir.pwd.inspect}"
    puts "FakeFS::FileSystem.normalize_path('.') => #{FakeFS::FileSystem.normalize_path('.').inspect}"
  end
end
```

The fix implemented here is to use `Pathname#+` to handle path resolution when there is at least one level of directories.
